### PR TITLE
Add support for all Hugging Face Chat, Text models + OpenAI, Claude2, Cohere, Palm, Replicate models

### DIFF
--- a/hf-endpoint/bench.py
+++ b/hf-endpoint/bench.py
@@ -5,6 +5,7 @@ import pandas as pd
 sys.path.append('../common/')
 from questions import questions
 from tqdm import tqdm
+from litellm import completion
 
 tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf",
                                           use_auth_token=True)
@@ -28,6 +29,19 @@ def generate(prompt):
             'time': request_time,
             'question': prompt,
             'answer': response.json()[0]['generated_text'],
+            'note': 'hf-endpoint'}
+
+def litellm_generate(prompt, model="meta-llama/llama-2-7b-hf"):
+    messages=[{"role":"user", "content": prompt}]
+    start = time.perf_counter()
+    response = completion(model=model, messages=messages) 
+    request_time = time.perf_counter() - start
+    text_response = response['choices'][0]['message']['content']
+    usage_tokens = response['usage']['completion_tokens']
+    return {'tok_count': usage_tokens,
+            'time': request_time,
+            'question': prompt,
+            'answer': text_response,
             'note': 'hf-endpoint'}
 
 if __name__ == '__main__':


### PR DESCRIPTION
@hamelsmu noticed you were using `meta-llama/llama-2-7b-hf`. I'm making this PR to add support for all text2text and text generation models on Hugging Face. 
I noticed most HF text models had different Input chat formats and outputs were not consistent. 


liteLLM allows you to call all HF models (and the above mentioned providers) with a standard Input/Output interface - in the chatGPT format 
More info here: https://github.com/BerriAI/litellm/ 