### PR TITLE
hf/bench.py: need to specify bfloat16 otherwise it consumes twice as much memory in A10.

### DIFF
--- a/hf/bench.py
+++ b/hf/bench.py
@@ -1,5 +1,6 @@
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
+import torch
 import time
 import sys
 sys.path.append('../common/')
@@ -8,7 +9,7 @@ import pandas as pd
 
 model_id = "meta-llama/Llama-2-7b-hf"
 tokenizer = AutoTokenizer.from_pretrained(model_id)
-model = AutoModelForCausalLM.from_pretrained(model_id)
+model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16)
 model.to("cuda")
 
 def predict(prompt:str):


### PR DESCRIPTION
BTW float16 gives wrong results in the A10 but correct on the T4 (which also doesn't work unless specifying the float16 type explicitly). Maybe related also to https://github.com/hamelsmu/llama-inference/issues/4